### PR TITLE
Fixes image / bundle publishing jobs

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -36,7 +36,7 @@ jobs:
           # and apply it over the bundle.yaml file.
           echo "applications:" > overlay.yaml
           echo "  finos-waltz:" >> overlay.yaml
-          echo "    channel: ${{ steps.release-short.outputs.short_version }}" }}/edge" >> overlay.yaml
+          echo "    channel: ${{ steps.release-short.outputs.short_version }}/edge" >> overlay.yaml
 
           # We can't have bundle.yaml as both the source and destionation, the result will not be
           # as we would have wanted it.
@@ -73,8 +73,13 @@ jobs:
           new_branch: "release-${{ github.event.inputs.release }}"
 
       - name: Upload bundle to edge
-        uses: canonical/charming-actions/upload-bundle@1.0.2
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.release-short.outputs.short_version }}/edge"
+        # TODO: replace with  canonical/charming-actions/upload-bundle once the following issue
+        # is resolved: https://github.com/canonical/charming-actions/issues/40
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+        run: |
+          charmcraft pack
+          charmcraft upload finos-waltz-bundle.zip
+          # Get the last revision number and image revision number and release.
+          bundle_rev=$(charmcraft revisions finos-waltz-bundle | awk 'FNR == 2 {print $1}')
+          charmcraft release finos-waltz-bundle --revision=${bundle_rev} --channel="${{ steps.release-short.outputs.short_version }}/edge"

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+      GH_TOKEN: "${{ secrets.GH_TOKEN }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,7 +60,7 @@ jobs:
             # Get the last revision number and image revision number and release.
             charm_rev=$(charmcraft revisions finos-waltz-k8s | awk 'FNR == 2 {print $1}')
             img_rev=$(charmcraft resource-revisions finos-waltz-k8s waltz-image | awk 'FNR == 2 {print $1}')
-            charmcraft release finos-waltz-k8s --revision=${charm_rev} --channel="${release_short}/edge" --resource="waltz-image:${img_rev}"
+            charmcraft release finos-waltz-k8s --revision=${charm_rev} --channel="${short_version}/edge" --resource="waltz-image:${img_rev}"
 
             # Also release it as the latest.
             charmcraft release finos-waltz-k8s --revision=${charm_rev} --channel=edge --resource="waltz-image:${img_rev}"
@@ -79,4 +80,9 @@ jobs:
             fi
 
             release_charm_with_image "${img_version}"
+
+            # Dispatch the create_release.yaml workflow, which will create the release branch,
+            # create a commit that will make bundle.yaml point towards this release, and publish
+            # the bundle into Charmhub.
+            gh workflow run create_release.yaml -f release="${img_version}"
           done


### PR DESCRIPTION
Dispatch ``create_release.yaml`` on a new release. The ``create_release.yaml`` action will create a new branch based on that release, create a commit which will update the ``bundle.yaml`` file to make the ``finos-waltz-k8s`` charm point towards that release, and push the new bundle to Charmhub.

When there's a new Waltz image release, we do a charmcraft release specific for that version in Charmhub.

We're manually packing and uploading the bundle instead of using the ``upload-bundle`` action because of an issue [1]. This will have to be updated later, when the issue is resolved.

[1] https://github.com/canonical/charming-actions/issues/40

Successful "Publish FINOS Waltz Images" action: https://github.com/claudiubelu/waltz-juju-bundle/runs/6044559597?check_suite_focus=true
Successful "Create FINOS Waltz release branch" action: https://github.com/claudiubelu/waltz-juju-bundle/actions/runs/2182954775