### PR TITLE
Disable rewrite for nginx-ingress-integrator charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -21,6 +21,8 @@ applications:
     channel: "stable"
     scale: 1
     trust: true
+    options:
+      rewrite-enabled: false
 
 relations:
   # Waltz DB relation:


### PR DESCRIPTION
Adds `rewrite-enabled: false` to the walz-ingress application so that
the path doesn't get rewritten to the default path (`/`).