### PR TITLE
Add `create_overlay` github action

### DIFF
--- a/.github/workflows/create_overlay.yaml
+++ b/.github/workflows/create_overlay.yaml
@@ -1,0 +1,71 @@
+name: Create FINOS Waltz release overlay
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "The release to create an overlay for (yyyy-mm-dd)"
+        type: string
+        required: true
+      waltz-image:
+        description: "The FINOS Waltz image used in the overlay"
+        type: string
+        required: true
+
+jobs:
+  create-overlay:
+    name: Create release overlay.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - id: release-short
+        run: |
+          # Use - as a delimiter, and get only the year and month (first 2 fields).
+          yyyy_mm=$(echo ${{ github.event.inputs.release }} | cut -d- -f1-2)
+          echo "::set-output name=yyyy_mm::$yyyy_mm"
+
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      - name: Checkout release-${{ github.event.inputs.release }} branch
+        uses: actions/checkout@v3
+        with:
+          ref: release-${{ github.event.inputs.release }}
+          fetch-depth: 0
+          clean: false
+
+      - name: Update bundle.yaml
+        run: |
+          # Create an overlay yaml file with the desired release version for Waltz
+          # and apply it over the bundle.yaml file.
+          overlay_file="overlay-${{ github.event.inputs.release }}.yaml"
+          echo "applications:" > $overlay_file
+          echo "  finos-waltz:" >> $overlay_file
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> $overlay_file
+          echo "    resources:" >> $overlay_file
+          echo "      waltz-image: ${{ github.event.inputs.waltz-image }}" >> $overlay_file
+
+      - name: Create commit
+        uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+        with:
+          # The arguments for the `git add` command (see the paragraph below for more info)
+          # Default: '.'
+          add: "overlay-${{ github.event.inputs.release }}.yaml"
+
+          # The name of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_name: Claudiu Belu
+
+          # The email of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_email: cbelu@cloudbasesolutions.com
+
+          # Additional arguments for the git commit command. The --message argument is already set by the message input.
+          # Default: ''
+          commit: --signoff
+
+          # The message for the commit.
+          # Default: 'Commit from GitHub Actions (name of the workflow)'
+          message: "Creates ${{ github.event.inputs.release }} release overlay.yaml file"

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Runs everyday at 00:00. (see https://crontab.guru)
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   publish-images:
@@ -85,4 +85,17 @@ jobs:
             # create a commit that will make bundle.yaml point towards this release, and publish
             # the bundle into Charmhub.
             gh workflow run create_release.yaml -f release="${img_version}"
+
+            # Wait until the branch is created
+            branch_url_code=$(curl -s -o /dev/null -w "%{http_code}" https://github.com/finos/waltz-juju-bundle/tree/release-${img_version})
+            while [ $branch_url_code -ne 200 ]
+              do
+                branch_url_code=$(curl -s -o /dev/null -w "%{http_code}" https://github.com/finos/waltz-juju-bundle/tree/release-${img_version})
+                echo Waiting for release-${img_version} branch to be created
+                echo $branch_url_code
+                sleep 30
+            done
+
+            gh workflow run create_overlay.yaml -f release="${img_version}" \
+              -f waltz-image="ghcr.io/finos/waltz:${img_version}"
           done


### PR DESCRIPTION
Adds the github action for creating an overlay for a release with a
specified Waltz image.