### PR TITLE
Adds information about the public dataset bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A Charmed bundle containing everything needed to deploy and operate Waltz on a K
 * [**postgresql-k8s**](https://charmhub.io/postgresql-k8s), responsible for creating a PostgreSQL database on demand for the related ``finos-waltz-k8s`` charm.
 * [**nginx-ingress-integrator**](https://charmhub.io/nginx-ingress-integrator), which manages the ingress traffic for the related ``finos-waltz-k8s`` charm, allowing users to connect to Waltz through a friendly, configurable ``service-hostname`` instead of an ephemeral IP.
 
+In addition to the charms above, [Waltz public bundle](https://github.com/finos/waltz-juju-bundle/blob/public/bundle.yaml) also contains the [**postgresql-data-k8s**](https://charmhub.io/postgresql-data-k8s) charm related to the ``postgresql-k8s`` charm, which will inject a public Waltz database sample into the Waltz database for demo purposes.
+
 >💡If you are evaluating Waltz, you can follow [this guide](/docs/guides/LocalDeployment.md) for a quick 10-minutes Waltz deployment. You will also learn how to provision a K8s cluster on your laptop using MicroK8s. You don't need to have any previous Kubernetes knowledge!
 
 ## Waltz 

--- a/docs/guides/LocalDeployment.md
+++ b/docs/guides/LocalDeployment.md
@@ -43,6 +43,14 @@ juju deploy --trust finos-waltz-bundle --channel=edge
 
 The bundle contains the following charms: ``finos-waltz-k8s``, ``postgresql-k8s``, and ``nginx-ingress-integrator``. The bundle also creates creates relations between the ``finos-waltz-k8s`` charm and the ``postgresql-k8s`` and ``nginx-ingress-integrator`` charms.
 
+Alternatively, you can deploy a demo bundle containing a public dataset injected into the Waltz database for testing purposes:
+
+```bash
+juju deploy --trust finos-waltz-bundle --channel=public/edge
+```
+
+This demo bundle also contains a ``postgresql-data-k8s`` charm which is configured with a [PostgreSQL database dump](https://github.com/finos/waltz/files/8390039/postgres-dump-1.40.sql.gz), which will be injected periodically into the Waltz database in the related ``postgresql-k8s`` charm. Other database samples for testing purposes can be found in the [Waltz repository](https://github.com/finos/waltz/tree/master/waltz-sample-data/database/pg).
+
 In another terminal, you can check the deployment status and the integration code running using `watch --color juju status --color`. All the charms should become Active after a few minutes.
 
 The FINOS Waltz charm will use the PostgreSQL database provisioned by the ``postgresql-k8s`` charm. Alternatively, you can configure it with an external PostgreSQL connection details:


### PR DESCRIPTION
The bundle published under the ``--channel=public/edge`` also contains a postgresql-data-k8s charm, which is configured with a PostgreSQL database dump containing a test dataset meant for testing purposes. This bundle can be used for trying out Waltz.

This commit adds information about in the documentation.