### PR TITLE
Pins nginx-ingress-integrator

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -18,7 +18,8 @@ applications:
 
   waltz-ingress:
     charm: "nginx-ingress-integrator"
-    channel: "stable"
+    channel: "edge"
+    revision: 79
     scale: 1
     trust: true
     options:


### PR DESCRIPTION
Recent revisions changed the way the relations with it work, which is incompatible with the current state of the Waltz charm.

Pinning to a revision which still works for us.