### PR TITLE
CI: Update publish-images runner to ubuntu-latest

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-images:
     name: Publish Waltz Images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
       GH_TOKEN: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
The runner is set to run on `ubuntu-20.04`, however, those runners have been removed, which means that the job will remain stuck in a Pending state.

Update the runner to `ubuntu-latest`.